### PR TITLE
Changes to make MZTimerLabel's instantiated in storyboards work...

### DIFF
--- a/MZTimerLabel/MZTimerLabel.m
+++ b/MZTimerLabel/MZTimerLabel.m
@@ -82,6 +82,17 @@
     return self;
 }
 
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+	self = [super initWithCoder:aDecoder];
+	if (self) {
+		_timeLabel = self;
+		_timerType = MZTimerLabelTypeStopWatch;
+		[self setup];
+	}
+	return self;
+}
+
 #pragma mark - Getter and Setter Method
 
 -(void)setStopWatchTime:(NSTimeInterval)time{
@@ -107,6 +118,9 @@
     _timeFormat = timeFormat;
     if ([_timeFormat length] != 0) {
         _timeFormat = timeFormat;
+        dateFormatter = [[NSDateFormatter alloc] init];
+        [dateFormatter setDateFormat:_timeFormat];
+        [dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:@"GMT"]];
     }
     [self updateLabel:nil];
 }


### PR DESCRIPTION
Add initWithCoder to allow proper initialization when initialized from nib/storyboard

Make sure dateFormatter is updated when the timeFormat is changed.

Both of these were needed when I tried to create a MZTimerLabel in a storyboard, and then initialize it once it had already been created.
