### PR TITLE
Fixed timer format when system uses 12-hour clock

### DIFF
--- a/MZTimerLabel/MZTimerLabel.m
+++ b/MZTimerLabel/MZTimerLabel.m
@@ -152,6 +152,7 @@
     
     if (_dateFormatter == nil) {
         _dateFormatter = [[NSDateFormatter alloc] init];
+        _dateFormatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_GB"];
         [_dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:@"GMT"]];
         _dateFormatter.dateFormat = self.timeFormat;
     }


### PR DESCRIPTION
There is currently an issue where if the device has 12-hour clock set in the system settings, the time format for the timer label will be incorrect.

For example, instead of displaying "00:02:00" it will display "12:02:00 am".

See the following discussions on Stack Overflow:
http://stackoverflow.com/questions/11062280/nsdateformatter-in-12-hour-mode
http://stackoverflow.com/questions/2135267/nsdateformatter-with-24-hour-times
