### PR TITLE
Add Time To Count Down Timer

### DIFF
--- a/MZTimerLabel/MZTimerLabel.m
+++ b/MZTimerLabel/MZTimerLabel.m
@@ -171,7 +171,7 @@
 
 -(void)addTimeCountedByTime:(NSTimeInterval)timeToAdd
 {
-    startCountDate = [startCountDate dateByAddingTimeInterval:-timeToAdd];
+    [self setCountDownTime:timeToAdd + timeUserValue];
     [self updateLabel];
 }
 


### PR DESCRIPTION
As Implemented:
-(void)addTimeCountedByTime:(NSTimeInterval)timeToAdd
{
startCountDate = [startCountDate dateByAddingTimeInterval:-timeToAdd];
[self updateLabel];
}

This method changes the start date, triggering a call to the delegate
method:
-(void)timerLabel:(MZTimerLabel*)timerLabel
finshedCountDownTimerWithTime:(NSTimeInterval)countTime;

when it is not the case. An Implementation that does add time to the
counted time without triggering a call to the delegate is:

-(void)addTimeCountedByTime:(NSTimeInterval)timeToAdd
{
[self setCountDownTime:timeToAdd + timeUserValue];
[self updateLabel];
}

Why the change was needed?
To avoid calls to -(void)timerLabel:(MZTimerLabel*)timerLabel
finshedCountDownTimerWithTime:(NSTimeInterval)countTime;

when the timer was actually not done.
