### PR TITLE
tvOS support

### DIFF
--- a/MZTimerLabel.podspec
+++ b/MZTimerLabel.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "MineS Chan" => "mineschan@gmail.com" }
 
-  s.platform     = :ios, '6.0'
+  s.ios.deployment_target = '6.0'
 
   s.source       = { :git => "https://github.com/mineschan/MZTimerLabel.git", :tag => s.version.to_s }
 

--- a/MZTimerLabel.podspec
+++ b/MZTimerLabel.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.author       = { "MineS Chan" => "mineschan@gmail.com" }
 
   s.ios.deployment_target = '6.0'
+  s.tvos.deployment_target = '9.0'
 
   s.source       = { :git => "https://github.com/mineschan/MZTimerLabel.git", :tag => s.version.to_s }
 


### PR DESCRIPTION
I used MZTimerLabel in a Swift project with tvOS target.

Add to `Podfile`

```
pod 'MZTimerLabel'
```

I created a .m file in my project:

`
(Right-click) -> New File... -> Objective-C File (.m) -> 'new bridging header?' -> YES
`

In the new `UIKitCatalog-Bridging-Header.h` file, add

```
#import "Pods/MZTimerLabel/MZTimerLabel/MZTimerLabel.h"
```

Add a MZTimerLabel outlet to your view controller

```
    @IBOutlet weak var timerLabel: MZTimerLabel!
```

It should work properly!
