### PR TITLE
retain circle 导致timerLabel不能释放

### DIFF
--- a/MZTimerLabel/MZTimerLabel.h
+++ b/MZTimerLabel/MZTimerLabel.h
@@ -72,7 +72,7 @@ typedef enum{
 @property (nonatomic,copy) NSString *timeFormat;
 
 /*Target label obejct, default self if you do not initWithLabel nor set*/
-@property (nonatomic,strong) UILabel *timeLabel;
+@property (nonatomic,weak) UILabel *timeLabel;
 
 /*Used for replace text in range */
 @property (nonatomic, assign) NSRange textRange;
@@ -110,6 +110,7 @@ typedef enum{
 #endif
 -(void)pause;
 -(void)reset;
+- (void)cleanTimerLabel;
 
 /*--------Setter methods*/
 -(void)setCountDownTime:(NSTimeInterval)time;

--- a/MZTimerLabel/MZTimerLabel.m
+++ b/MZTimerLabel/MZTimerLabel.m
@@ -101,7 +101,14 @@
 
 #pragma mark - Cleanup
 
-- (void) removeFromSuperview {
+- (void)cleanTimerLabel {
+    if (_timer) {
+        [_timer invalidate];
+        _timer = nil;
+    }
+}
+
+- (void)removeFromSuperview {
     if (_timer) {
         [_timer invalidate];
         _timer = nil;


### PR DESCRIPTION
1
- (UILabel*)timeLabel
{
if (_timeLabel == nil) {
_timeLabel = self;
}
return _timeLabel;
}

如果_timeLabel = self，由于self.timerLabel是strong，会形成retainCircle

2 timer 和self 也会形成retain
circle，需要在不使用timer时调用一下cleanTimerLabel，比如在一个ViewController的dealloc中调用cle
anTimerLabel