### PR TITLE
change property timeLabel from strong to weak to avoid reatin cycle.

### DIFF
--- a/MZTimerLabel/MZTimerLabel.h
+++ b/MZTimerLabel/MZTimerLabel.h
@@ -73,7 +73,7 @@ typedef enum{
 @property (nonatomic,copy) NSString *timeFormat;
 
 /*Target label obejct, default self if you do not initWithLabel nor set*/
-@property (nonatomic,strong) UILabel *timeLabel;
+@property (nonatomic,weak) UILabel *timeLabel;
 
 /*Used for replace text in range */
 @property (nonatomic, assign) NSRange textRange;


### PR DESCRIPTION
I used this amazing label for my project, it's perfect for my requirements (😄 thanks, bro.) , but I found that the timeLabel property might have retain cycle issue.
```objetive-c
- (UILabel*)timeLabel {
    if (_timeLabel == nil) {
        _timeLabel = self;
    }
    return _timeLabel;
}
```
when no specific UILabel object was passed into this object, it will make the timeLabel pointer point to itself ( which is strong assignment), cause the retain cycle.
I tested on my device and that is the case.

I make a demo view controller and add this label as a subview of it.
when I quit the demo view controller. The object still exist on mem graph, which means mem leak (caused by the ivar: _timeLabel)
![CleanShot 2023-05-15 at 23 08 53@2x](https://github.com/mineschan/MZTimerLabel/assets/39005916/f6059514-5f46-4d44-9ee2-38331c884b2c)

if I make it weak property, it will dealloc properly.
![CleanShot 2023-05-15 at 23 10 54@2x](https://github.com/mineschan/MZTimerLabel/assets/39005916/3a6409eb-d378-4767-9568-2527e4285898)

(I re-opened this pr, because I forgot to create a new branch lol.)